### PR TITLE
refactor: oauth api 분리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 /src/main/resources/application.properties
+/20-real-be-properties
 
 ### STS ###
 .apt_generated

--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,11 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 tasks.named('test') {

--- a/src/main/java/com/real/backend/config/QueryDslConfig.java
+++ b/src/main/java/com/real/backend/config/QueryDslConfig.java
@@ -1,0 +1,18 @@
+package com.real.backend.config;
+
+import org.springframework.context.annotation.Bean;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+
+public class QueryDslConfig {
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/com/real/backend/config/SecurityConfig.java
+++ b/src/main/java/com/real/backend/config/SecurityConfig.java
@@ -55,7 +55,7 @@ public class SecurityConfig {
         http
                 .authorizeHttpRequests((auth) -> auth
                         .requestMatchers("/auth/**").permitAll() // 필터 거치지 않고 통과
-                        .requestMatchers("/api/v1/oauth/**").permitAll()
+                        .requestMatchers("/api/v1/oauth/**", "/api/v1/news").permitAll()
                         .anyRequest().authenticated()  // 나머지는 필터 통과
                 );
 

--- a/src/main/java/com/real/backend/global/BaseEntity.java
+++ b/src/main/java/com/real/backend/global/BaseEntity.java
@@ -8,8 +8,10 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
 
 @MappedSuperclass
+@Getter
 @EntityListeners(AuditingEntityListener.class)
 public abstract class BaseEntity {
     @CreatedDate

--- a/src/main/java/com/real/backend/news/NewsController.java
+++ b/src/main/java/com/real/backend/news/NewsController.java
@@ -1,0 +1,30 @@
+package com.real.backend.news;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.real.backend.news.dto.NewsSliceDTO;
+import com.real.backend.response.DataResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class NewsController {
+
+    private final NewsService newsService;
+
+    @GetMapping("/v1/news")
+    public DataResponse<NewsSliceDTO> getAllNews(@RequestParam(value = "cursorId", required = false) Long cursorId,
+        @RequestParam(value = "cursorStandard", required = false) String cursorStandard,
+        @RequestParam(value = "limit", required = false, defaultValue = "10") int limit,
+        @RequestParam("sort") String sort) {
+
+        NewsSliceDTO newsList = newsService.getAllNews(cursorId, limit, sort, cursorStandard);
+        return DataResponse.of(newsList);
+
+    }
+}

--- a/src/main/java/com/real/backend/news/NewsService.java
+++ b/src/main/java/com/real/backend/news/NewsService.java
@@ -1,0 +1,77 @@
+package com.real.backend.news;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+
+import com.real.backend.exception.BadRequestException;
+import com.real.backend.news.domain.News;
+import com.real.backend.news.dto.NewsListResponseDTO;
+import com.real.backend.news.dto.NewsSliceDTO;
+import com.real.backend.news.repository.NewsRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class NewsService {
+
+    private final NewsRepository newsRepository;
+
+    public NewsSliceDTO getAllNews(Long cursorId, int limit, String sort, String cursorStandard) {
+
+        String order = (sort == null || sort.isBlank()) ? "latest" : sort.toLowerCase();
+
+        if (!order.equals("latest") && !order.equals("popular")) {
+            throw new BadRequestException("sort 파라미터는 latest 또는 popular 이어야 합니다.");
+        }
+
+        Pageable pg = PageRequest.of(0, limit + 1);
+        boolean firstPage = (cursorId == null || cursorStandard == null);
+        Slice<News> slice;
+
+        if (order.equals("latest")) {
+
+            if (firstPage) {
+                slice = newsRepository.fetchLatestFirst(pg);
+            } else {
+                LocalDateTime cAt = LocalDateTime.parse(cursorStandard);
+                slice = newsRepository.fetchLatest(cAt, cursorId, pg);
+            }
+
+        } else {
+
+            if (firstPage) {
+                slice = newsRepository.fetchPopularFirst(pg);
+            } else {
+                Long views = Long.parseLong(cursorStandard);
+                slice = newsRepository.fetchPopular(views, cursorId, pg);
+            }
+        }
+
+        List<News> content = slice.getContent();
+        boolean hasNext = slice.hasNext();
+        List<News> pageItems = content.size() > limit ? content.subList(0, limit) : content;
+
+        // 다음 커서 계산
+        String nextCursor = null;
+        Long nextCursorId = null;
+        if (hasNext) {
+            News last = pageItems.get(pageItems.size() - 1);
+            nextCursor = order.equals("latest")
+                    ? last.getCreatedAt().toString()
+                    : String.valueOf(last.getTodayViewCount());
+            nextCursorId = last.getId();
+        }
+
+        List<NewsListResponseDTO> dtoList = pageItems.stream()
+            .map(NewsListResponseDTO::of)
+            .toList();
+
+        return new NewsSliceDTO(dtoList, nextCursor, nextCursorId, hasNext);
+    }
+}

--- a/src/main/java/com/real/backend/news/dto/NewsListResponseDTO.java
+++ b/src/main/java/com/real/backend/news/dto/NewsListResponseDTO.java
@@ -1,0 +1,28 @@
+package com.real.backend.news.dto;
+
+import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.real.backend.news.domain.News;
+import lombok.Builder;
+
+@Builder
+public record NewsListResponseDTO(
+    long id,
+    String title,
+    long commentCount,
+    long todayViewCount,
+    String imageUrl,
+    @JsonFormat(pattern = "yyyy.MM.dd HH:mm:ss")
+    LocalDateTime createdAt) {
+    public static NewsListResponseDTO of(News news) {
+        return NewsListResponseDTO.builder()
+                    .id(news.getId())
+                    .title(news.getTitle())
+                    .commentCount(news.getCommentCount())
+                    .todayViewCount(news.getTodayViewCount())
+                    .imageUrl(news.getImageUrl())
+                    .createdAt(news.getCreatedAt())
+                    .build();
+    }
+}

--- a/src/main/java/com/real/backend/news/dto/NewsSliceDTO.java
+++ b/src/main/java/com/real/backend/news/dto/NewsSliceDTO.java
@@ -1,0 +1,9 @@
+package com.real.backend.news.dto;
+
+import java.util.List;
+
+public record NewsSliceDTO(
+    List<NewsListResponseDTO> items,
+    String nextCursorStandard,
+    Long nextCursorId,
+    boolean hasNext) {}

--- a/src/main/java/com/real/backend/news/repository/NewsRepository.java
+++ b/src/main/java/com/real/backend/news/repository/NewsRepository.java
@@ -1,8 +1,52 @@
 package com.real.backend.news.repository;
 
+import java.time.LocalDateTime;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 
 import com.real.backend.news.domain.News;
 
+@Repository
 public interface NewsRepository extends JpaRepository<News, Long> {
+    @Query("""
+        SELECT n FROM News n
+        WHERE  n.deletedAt IS NULL
+        ORDER  BY n.createdAt DESC, n.id DESC
+        """)
+    Slice<News> fetchLatestFirst(Pageable pg);   // 첫 페이지
+
+    @Query("""
+        SELECT n FROM News n
+        WHERE  n.deletedAt IS NULL
+          AND ( n.createdAt < :cAt
+                OR (n.createdAt = :cAt AND n.id < :id) )
+        ORDER BY n.createdAt DESC, n.id DESC
+        """)
+    Slice<News> fetchLatest(@Param("cAt") LocalDateTime cAt,
+        @Param("id") Long id,
+        Pageable pg);
+
+    /* 인기순 ------------------------------------------------------------ */
+    @Query("""
+        SELECT n FROM News n
+        WHERE  n.deletedAt IS NULL
+        ORDER  BY n.todayViewCount DESC, n.id DESC
+        """)
+    Slice<News> fetchPopularFirst(Pageable pg);
+
+    @Query("""
+        SELECT n FROM News n
+        WHERE  n.deletedAt IS NULL
+          AND ( n.todayViewCount < :views
+                OR (n.todayViewCount = :views AND n.id < :id) )
+        ORDER BY n.todayViewCount DESC, n.id DESC
+        """)
+    Slice<News> fetchPopular(@Param("views") Long views,
+        @Param("id")    Long id,
+        Pageable pg);
 }

--- a/src/main/java/com/real/backend/oauth/controller/KakaoController.java
+++ b/src/main/java/com/real/backend/oauth/controller/KakaoController.java
@@ -1,14 +1,10 @@
 package com.real.backend.oauth.controller;
 
-import java.io.IOException;
-
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.real.backend.oauth.kakao.KakaoUtil;
 import com.real.backend.oauth.service.AuthService;
 import com.real.backend.response.DataResponse;
 import com.real.backend.user.domain.User;
@@ -20,14 +16,17 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/api")
-public class AuthController {
+public class KakaoController {
+    private final AuthService authService;
 
-    private final KakaoUtil kakaoUtil;
-
-    @GetMapping("/v1/oauth/{provider}")
-    public void oauthLogin(@PathVariable("provider") String provider, HttpServletResponse response) throws IOException {
-        if (provider.equals("kakao")) {
-            response.sendRedirect(kakaoUtil.redirectToKakaoLogin());
-        }
+    @GetMapping("/v1/oauth/kakao/callback")
+    public DataResponse<LoginResponseDTO> kakaoLogin(@RequestParam("code") String accessCode, HttpServletResponse response) {
+        User user = authService.oAuthLogin(accessCode, response);
+        return DataResponse.of(LoginResponseDTO.builder()
+            .nickname(user.getNickname())
+            .role(user.getRole())
+            .profileUrl(user.getProfileUrl())
+            .build());
     }
+
 }

--- a/src/main/java/com/real/backend/oauth/kakao/KakaoUtil.java
+++ b/src/main/java/com/real/backend/oauth/kakao/KakaoUtil.java
@@ -16,6 +16,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.real.backend.oauth.dto.KakaoProfileDTO;
 import com.real.backend.oauth.dto.KakaoTokenDTO;
 
+import jakarta.servlet.http.HttpServletResponse;
+
 @Component
 public class KakaoUtil {
 
@@ -84,4 +86,14 @@ public class KakaoUtil {
 
         return kakaoProfile;
     }
+
+    public String redirectToKakaoLogin(){
+        return "https://kauth.kakao.com/oauth/authorize?"
+            + "response_type=code"
+            + "&client_id=" + apiKey
+            + "&redirect_uri=" + redirectUri;
+
+    }
+
+
 }

--- a/src/main/java/com/real/backend/oauth/service/AuthService.java
+++ b/src/main/java/com/real/backend/oauth/service/AuthService.java
@@ -59,6 +59,4 @@ public class AuthService {
         return user;
 
     }
-
-
 }

--- a/src/main/java/com/real/backend/security/filter/JwtFilter.java
+++ b/src/main/java/com/real/backend/security/filter/JwtFilter.java
@@ -84,7 +84,7 @@ public class JwtFilter extends OncePerRequestFilter {
     }
 
     private boolean shouldSkip(HttpServletRequest request) {
-        List<String> skipURI = Arrays.asList("/login", "/auth/.*", "/users/signup", "/api/v1/oauth/.*");
+        List<String> skipURI = Arrays.asList("/login", "/auth/.*", "/users/signup", "/api/v1/oauth/.*", "/api/v1/news");
 
         return skipURI.stream().anyMatch(uri -> {
             Pattern pattern = Pattern.compile(uri);


### PR DESCRIPTION
### Description

oauth api 분리 및 path parameter를 받기로 변경

### Related Issues

- Resolves #11 

### Changes Made

1. oauth api 분리
2. /api/v1/oauth/{provider} 로 엔드포인트를 변경하여 여러 oauth 제공자의 확장성을 고려함

### Checklist

- [ X ] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [ X ] 모든 테스트가 성공적으로 통과했습니다.
- [ X ] 관련 문서를 업데이트했습니다.
- [ X ] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [ X ] 코드 스타일 가이드라인을 준수했습니다.
- [ X ] 코드 리뷰어를 지정했습니다.
