### PR TITLE
♻️ fix: Post 엔티티의 content 컬럼 타입을 TEXT로 변경

### DIFF
--- a/src/main/java/com/real/backend/post/Post.java
+++ b/src/main/java/com/real/backend/post/Post.java
@@ -27,7 +27,7 @@ public abstract class Post extends BaseEntity {
 
     @Column(nullable = false)
     private String title;
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     private String content;
     @Column(nullable = false)
     private String tag;


### PR DESCRIPTION
### Description
- Post 엔티티 content 타입 변경 
  - 기존: VARCHAR(255)
  - 개선: TEXT

### Related Issues
- Fixes #42
