### PR TITLE
🐛 fix: 공지 생성시 날짜 반영 안되는 버그 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,7 @@ dependencies {
     implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
     implementation 'software.amazon.awssdk:s3:2.20.137' // AWS SDK v2
     implementation 'com.googlecode.owasp-java-html-sanitizer:owasp-java-html-sanitizer:20211018.1' // Sanitizer
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis' // redis
     annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"

--- a/src/main/java/com/real/backend/batch/PostCountScheduler.java
+++ b/src/main/java/com/real/backend/batch/PostCountScheduler.java
@@ -21,7 +21,8 @@ public class PostCountScheduler {
     private final NewsRepository newsRepository;
 
     @Transactional
-    @Scheduled(cron = "*/3 * * * * *")
+    @Scheduled(cron = "* * */3 * * *")
+    // @Scheduled(cron = "*/1 * * * * *")
     public void syncNoticeCountsToDB() {
         List<Long> noticeIds = postRedisService.getIds("notice", "totalView");
 
@@ -35,7 +36,8 @@ public class PostCountScheduler {
     }
 
     @Transactional
-    @Scheduled(cron = "*/3 * * * * *")
+    @Scheduled(cron = "* * */3 * * *")
+    // @Scheduled(cron = "*/1 * * * * *")
     public void syncNewsCountsToDB() {
         List<Long> newsIds = postRedisService.getIds("news", "totalView");
 

--- a/src/main/java/com/real/backend/batch/PostCountScheduler.java
+++ b/src/main/java/com/real/backend/batch/PostCountScheduler.java
@@ -1,0 +1,61 @@
+package com.real.backend.batch;
+
+import java.util.List;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.real.backend.domain.news.repository.NewsRepository;
+import com.real.backend.domain.notice.repository.NoticeRepository;
+import com.real.backend.infra.redis.PostRedisService;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class PostCountScheduler {
+
+    private final PostRedisService postRedisService;
+    private final NoticeRepository noticeRepository;
+    private final NewsRepository newsRepository;
+
+    @Transactional
+    @Scheduled(cron = "*/3 * * * * *")
+    public void syncNoticeCountsToDB() {
+        List<Long> noticeIds = postRedisService.getIds("notice", "totalView");
+
+        for (Long noticeId : noticeIds) {
+            Long totalView = postRedisService.getCount("notice", "totalView", noticeId);
+            Long likeCount = postRedisService.getCount("notice", "like", noticeId);
+            Long commentCount = postRedisService.getCount("notice", "comment", noticeId);
+
+            noticeRepository.updateCounts(noticeId, totalView, likeCount, commentCount);
+        }
+    }
+
+    @Transactional
+    @Scheduled(cron = "*/3 * * * * *")
+    public void syncNewsCountsToDB() {
+        List<Long> newsIds = postRedisService.getIds("news", "totalView");
+
+        for (Long newsId : newsIds) {
+            Long totalView = postRedisService.getCount("news", "totalView", newsId);
+            Long todayView = postRedisService.getCount("news", "todayView", newsId);
+            Long likeCount = postRedisService.getCount("news", "like", newsId);
+            Long commentCount = postRedisService.getCount("news", "comment", newsId);
+
+            newsRepository.updateCounts(newsId, totalView, todayView, likeCount, commentCount);
+        }
+    }
+
+    @Transactional
+    @Scheduled(cron = "0 0 0 * * *")
+    protected void resetTodayViewCount() {
+        List<Long> newsIds = postRedisService.getIds("news", "todayView");
+        for (Long newsId : newsIds) {
+            postRedisService.delete("news", "todayView", newsId);
+        }
+        newsRepository.resetTodayViewCount();
+    }
+}

--- a/src/main/java/com/real/backend/config/RedisConfig.java
+++ b/src/main/java/com/real/backend/config/RedisConfig.java
@@ -1,0 +1,37 @@
+package com.real.backend.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableRedisRepositories
+public class RedisConfig {
+    @Value("${spring.redis.host}")
+    private String redisHost;
+
+    @Value("${spring.redis.port}")
+    private int redisPort;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(redisHost, redisPort);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+        redisTemplate.setHashValueSerializer(new StringRedisSerializer());
+        return redisTemplate;
+    }
+
+}

--- a/src/main/java/com/real/backend/config/RedisConfig.java
+++ b/src/main/java/com/real/backend/config/RedisConfig.java
@@ -7,15 +7,16 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
 @EnableRedisRepositories
 public class RedisConfig {
-    @Value("${spring.redis.host}")
+    @Value("${spring.data.redis.host}")
     private String redisHost;
 
-    @Value("${spring.redis.port}")
+    @Value("${spring.data.redis.port}")
     private int redisPort;
 
     @Bean
@@ -28,9 +29,9 @@ public class RedisConfig {
         RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
         redisTemplate.setConnectionFactory(redisConnectionFactory());
         redisTemplate.setKeySerializer(new StringRedisSerializer());
-        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
         redisTemplate.setHashKeySerializer(new StringRedisSerializer());
-        redisTemplate.setHashValueSerializer(new StringRedisSerializer());
+        redisTemplate.setHashValueSerializer(new GenericJackson2JsonRedisSerializer());
         return redisTemplate;
     }
 

--- a/src/main/java/com/real/backend/domain/news/controller/NewsController.java
+++ b/src/main/java/com/real/backend/domain/news/controller/NewsController.java
@@ -44,7 +44,6 @@ public class NewsController {
     @PreAuthorize("!hasAnyAuthority('OUTSIDER')")
     @GetMapping("/v1/news/{newsId}")
     public DataResponse<NewsResponseDTO> getNewsById(@PathVariable("newsId") Long newsId, @CurrentSession Session session) {
-        newsService.increaseViewCounts(newsId);
         NewsResponseDTO newsResponseDTO = newsService.getNewsWithUserLiked(newsId, session.getId());
 
         return DataResponse.of(newsResponseDTO);

--- a/src/main/java/com/real/backend/domain/news/domain/News.java
+++ b/src/main/java/com/real/backend/domain/news/domain/News.java
@@ -28,7 +28,4 @@ public class News extends Post {
 
     @OneToMany(mappedBy = "news", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<NewsLike> newsLikes;
-
-    public void increaseTodayViewCount() {this.todayViewCount++;}
-
 }

--- a/src/main/java/com/real/backend/domain/news/dto/NewsResponseDTO.java
+++ b/src/main/java/com/real/backend/domain/news/dto/NewsResponseDTO.java
@@ -30,16 +30,16 @@ public class NewsResponseDTO {
     @JsonFormat(pattern = "yyyy.MM.dd HH:mm:ss")
     private LocalDateTime createdAt;
 
-    public static NewsResponseDTO from(News news, boolean userLike) {
+    public static NewsResponseDTO from(News news, boolean userLike, long viewCount, long likeCount, long commentCount) {
         return NewsResponseDTO.builder()
             .id(news.getId())
             .title(news.getTitle())
             .summary(news.getSummary())
             .content(news.getContent())
             .tag(news.getTag())
-            .viewCount(news.getTotalViewCount())
-            .likeCount(news.getLikeCount())
-            .commentCount(news.getCommentCount())
+            .viewCount(viewCount)
+            .likeCount(likeCount)
+            .commentCount(commentCount)
             .userLike(userLike)
             .imageUrl(news.getImageUrl())
             .createdAt(news.getCreatedAt())

--- a/src/main/java/com/real/backend/domain/news/repository/NewsRepository.java
+++ b/src/main/java/com/real/backend/domain/news/repository/NewsRepository.java
@@ -54,4 +54,8 @@ public interface NewsRepository extends JpaRepository<News, Long> {
     @Modifying
     @Query("UPDATE News n SET n.todayViewCount = 0")
     void resetTodayViewCount();
+
+    @Modifying
+    @Query("UPDATE News n SET n.totalViewCount = :totalView, n.todayViewCount = :todayViewCount, n.likeCount = :likeCount, n.commentCount = :commentCount WHERE n.id = :id")
+    void updateCounts(Long id, Long totalView, Long todayViewCount, Long likeCount, Long commentCount);
 }

--- a/src/main/java/com/real/backend/domain/news/service/NewsService.java
+++ b/src/main/java/com/real/backend/domain/news/service/NewsService.java
@@ -23,6 +23,7 @@ import com.real.backend.exception.ServerException;
 import com.real.backend.infra.ai.dto.NewsAiRequestDTO;
 import com.real.backend.infra.ai.dto.NewsAiResponseDTO;
 import com.real.backend.infra.ai.service.NewsAiService;
+import com.real.backend.infra.redis.PostRedisService;
 import com.real.backend.util.S3Utils;
 import com.real.backend.util.dto.SliceDTO;
 
@@ -34,6 +35,7 @@ public class NewsService {
 
     private final NewsRepository newsRepository;
     private final NewsLikeService newsLikeService;
+    private final PostRedisService postRedisService;
     private final NewsFinder newsFinder;
     private final S3Utils s3Utils;
     private final NewsAiService newsAiService;
@@ -95,7 +97,18 @@ public class NewsService {
     @Transactional(readOnly = true)
     public NewsResponseDTO getNewsWithUserLiked(Long newsId, Long userId) {
         News news = newsFinder.getNews(newsId);
-        return NewsResponseDTO.from(news, newsLikeService.userIsLiked(newsId, userId));
+
+        postRedisService.initCount("news", "totalView", newsId, news.getTotalViewCount());
+        postRedisService.initCount("news", "todayView", newsId, news.getTodayViewCount());
+        postRedisService.initCount("news", "like", newsId, news.getLikeCount());
+        postRedisService.initCount("news", "comment", newsId, news.getCommentCount());
+
+        long totalViewCount = postRedisService.increment("news", "totalView", newsId);
+        long todayViewCount = postRedisService.increment("news", "todayView", newsId);
+        long likeCount = postRedisService.getCount("news", "like", newsId);
+        long commentCount = postRedisService.getCount("news", "comment", newsId);
+
+        return NewsResponseDTO.from(news, newsLikeService.userIsLiked(newsId, userId), totalViewCount, likeCount, commentCount);
     }
 
     @Transactional
@@ -136,11 +149,5 @@ public class NewsService {
             .likeCount(0L)
             .commentCount(0L)
             .build());
-    }
-
-    @Transactional
-    @Scheduled(cron = "0 0 0 * * *")
-    protected void resetTodayViewCount() {
-        newsRepository.resetTodayViewCount();
     }
 }

--- a/src/main/java/com/real/backend/domain/news/service/NewsService.java
+++ b/src/main/java/com/real/backend/domain/news/service/NewsService.java
@@ -111,14 +111,6 @@ public class NewsService {
         return NewsResponseDTO.from(news, newsLikeService.userIsLiked(newsId, userId), totalViewCount, likeCount, commentCount);
     }
 
-    @Transactional
-    public void increaseViewCounts(Long newsId) {
-        News news = newsFinder.getNews(newsId);
-
-        news.increaseTodayViewCount();
-        news.increaseTotalViewCount();
-        newsRepository.save(news);
-    }
 
     @Transactional
     public void createNews(NewsCreateRequestDTO newsCreateRequestDTO, MultipartFile image) throws

--- a/src/main/java/com/real/backend/domain/notice/controller/NoticeController.java
+++ b/src/main/java/com/real/backend/domain/notice/controller/NoticeController.java
@@ -49,7 +49,6 @@ public class NoticeController {
         return DataResponse.of(noticeList);
     }
 
-    // TODO 파일 받는 로직
     @PreAuthorize("!hasAnyAuthority('OUTSIDER', 'TRAINEE')")
     @PostMapping("/v1/notices")
     public StatusResponse createNotice(

--- a/src/main/java/com/real/backend/domain/notice/controller/NoticeController.java
+++ b/src/main/java/com/real/backend/domain/notice/controller/NoticeController.java
@@ -66,7 +66,6 @@ public class NoticeController {
         @PathVariable Long noticeId,
         @CurrentSession Session session
     ) {
-        noticeService.increaseViewCounts(noticeId);
         noticeService.userReadNotice(noticeId, session.getId());
         NoticeInfoResponseDTO noticeInfoResponseDTO = noticeService.getNoticeById(noticeId, session.getId());
 

--- a/src/main/java/com/real/backend/domain/notice/dto/NoticeInfoResponseDTO.java
+++ b/src/main/java/com/real/backend/domain/notice/dto/NoticeInfoResponseDTO.java
@@ -31,6 +31,8 @@ public class NoticeInfoResponseDTO {
     public static NoticeInfoResponseDTO from(
         Notice notice,
         Boolean userLike,
+        Long likeCount,
+        Long commentCount,
         List<NoticeFilesResponseDTO> files,
         List<NoticeFilesResponseDTO> images) {
 
@@ -42,8 +44,8 @@ public class NoticeInfoResponseDTO {
             .content(notice.getContent())
             .summary(notice.getSummary())
             .tag(notice.getTag())
-            .likeCount(notice.getLikeCount())
-            .commentCount(notice.getCommentCount())
+            .likeCount(likeCount)
+            .commentCount(commentCount)
             .originalUrl(notice.getOriginalUrl())
             .userLike(userLike)
             .createdAt(notice.getCreatedAt())

--- a/src/main/java/com/real/backend/domain/notice/repository/NoticeRepository.java
+++ b/src/main/java/com/real/backend/domain/notice/repository/NoticeRepository.java
@@ -6,6 +6,7 @@ import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -90,4 +91,8 @@ public interface NoticeRepository extends JpaRepository<Notice, Long> {
            )
         """)
     List<Notice> findAllUnreadNotices(@Param("userId") Long userId);
+
+    @Modifying
+    @Query("UPDATE Notice n SET n.totalViewCount = :totalView, n.likeCount = :likeCount, n.commentCount = :commentCount WHERE n.id = :id")
+    void updateCounts(Long id, Long totalView, Long likeCount, Long commentCount);
 }

--- a/src/main/java/com/real/backend/domain/notice/service/NoticeCommentService.java
+++ b/src/main/java/com/real/backend/domain/notice/service/NoticeCommentService.java
@@ -20,6 +20,7 @@ import com.real.backend.domain.user.component.UserFinder;
 import com.real.backend.domain.user.domain.User;
 import com.real.backend.exception.ForbiddenException;
 import com.real.backend.exception.NotFoundException;
+import com.real.backend.infra.redis.PostRedisService;
 import com.real.backend.util.dto.SliceDTO;
 
 import lombok.RequiredArgsConstructor;
@@ -27,6 +28,7 @@ import lombok.RequiredArgsConstructor;
 @Service
 @RequiredArgsConstructor
 public class NoticeCommentService {
+    private final PostRedisService postRedisService;
     private final NoticeCommentRepository noticeCommentRepository;
     private final NoticeRepository noticeRepository;
     private final UserFinder userFinder;
@@ -73,13 +75,16 @@ public class NoticeCommentService {
     public void createNoticeComment(Long noticeId, Long userId, NoticeCommentRequestDTO noticeCommentRequestDTO) {
         User user = userFinder.getUser(userId);
         Notice notice = noticeFinder.getNotice(noticeId);
-        notice.increaseCommentCount();
+        // notice.increaseCommentCount();
+        postRedisService.initCount("notice", "comment", noticeId, notice.getCommentCount());
+        Long commentCount = postRedisService.increment("notice", "comment", noticeId);
+
 
         noticeCommentRepository.save(NoticeComment.builder()
             .content(noticeCommentRequestDTO.getContent())
             .user(user)
             .notice(notice)
             .build());
-        noticeRepository.save(notice);
+        // noticeRepository.save(notice);
     }
 }

--- a/src/main/java/com/real/backend/domain/notice/service/NoticeCommentService.java
+++ b/src/main/java/com/real/backend/domain/notice/service/NoticeCommentService.java
@@ -58,6 +58,7 @@ public class NoticeCommentService {
         );
     }
 
+    //TODO initcount를 먼저 레디스에 값이 있는지 확인을 하고 db에서 꺼내는 방법으로 변경하기
     @Transactional
     public void deleteNoticeComment(Long noticeId, Long commentId, Long userId) {
         Notice notice = noticeFinder.getNotice(noticeId);
@@ -67,8 +68,10 @@ public class NoticeCommentService {
             throw new ForbiddenException("해당 댓글 작성자가 아닙니다.");
         }
         noticeComment.delete();
-        notice.decreaseCommentCount();
-        noticeRepository.save(notice);
+        // notice.decreaseCommentCount();
+        postRedisService.initCount("notice", "comment", noticeId, notice.getCommentCount());
+        postRedisService.decrement("notice", "comment", noticeId);
+        // noticeRepository.save(notice);
     }
 
     @Transactional

--- a/src/main/java/com/real/backend/domain/notice/service/NoticeService.java
+++ b/src/main/java/com/real/backend/domain/notice/service/NoticeService.java
@@ -124,14 +124,6 @@ public class NoticeService {
     }
 
     @Transactional
-    public void increaseViewCounts(Long noticeId) {
-        Notice notice = noticeFinder.getNotice(noticeId);
-
-        notice.increaseTotalViewCount();
-        noticeRepository.save(notice);
-    }
-
-    @Transactional
     public void userReadNotice(Long noticeId, Long userId) {
         User user = userFinder.getUser(userId);
         Notice notice = noticeFinder.getNotice(noticeId);

--- a/src/main/java/com/real/backend/domain/notice/service/NoticeService.java
+++ b/src/main/java/com/real/backend/domain/notice/service/NoticeService.java
@@ -171,8 +171,6 @@ public class NoticeService {
             throw new ServerException("ai가 응답을 주지 못했습니다.");
         }
 
-        LocalDateTime createTime = LocalDateTime.parse(noticeCreateRequestDTO.getCreatedAt());
-
         Notice notice = Notice.builder()
             .user(user)
             .title(noticeCreateRequestDTO.getTitle())
@@ -184,9 +182,9 @@ public class NoticeService {
             .totalViewCount(0L)
             .commentCount(0L)
             .likeCount(0L)
-            .createdAt(createTime)
             .build();
 
+        noticeRepository.save(notice);
         notice.updateCreatedAt(noticeCreateRequestDTO.getCreatedAt());
         noticeRepository.save(notice);
 

--- a/src/main/java/com/real/backend/domain/notice/service/NoticeService.java
+++ b/src/main/java/com/real/backend/domain/notice/service/NoticeService.java
@@ -15,7 +15,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.real.backend.domain.notice.domain.Notice;
 import com.real.backend.domain.notice.component.NoticeFinder;
 import com.real.backend.domain.notice.dto.NoticePasteRequestDTO;
-import com.real.backend.domain.notice.repository.NoticeFileRepository;
 import com.real.backend.domain.user.domain.UserNoticeRead;
 import com.real.backend.domain.notice.dto.NoticeCreateRequestDTO;
 import com.real.backend.domain.notice.dto.NoticeFileGroups;
@@ -31,8 +30,8 @@ import com.real.backend.exception.ServerException;
 import com.real.backend.infra.ai.dto.NoticeSummaryRequestDTO;
 import com.real.backend.infra.ai.dto.NoticeSummaryResponseDTO;
 import com.real.backend.infra.ai.service.NoticeAiService;
+import com.real.backend.infra.redis.PostRedisService;
 import com.real.backend.util.CursorUtils;
-import com.real.backend.util.S3Utils;
 import com.real.backend.util.dto.SliceDTO;
 
 import lombok.RequiredArgsConstructor;
@@ -43,6 +42,7 @@ public class NoticeService {
     private final NoticeLikeService noticeLikeService;
     private final NoticeFileService noticeFileService;
     private final NoticeAiService noticeAiService;
+    private final PostRedisService postRedisService;
     private final UserRepository userRepository;
     private final NoticeRepository noticeRepository;
     private final UserNoticeReadRepository userNoticeReadRepository;
@@ -110,8 +110,17 @@ public class NoticeService {
     @Transactional(readOnly = true)
     public NoticeInfoResponseDTO getNoticeById(Long noticeId, Long userId) {
         Notice notice = noticeFinder.getNotice(noticeId);
+
+        postRedisService.initCount("notice", "totalView", noticeId, notice.getTotalViewCount());
+        postRedisService.initCount("notice", "like", noticeId, notice.getLikeCount());
+        postRedisService.initCount("notice", "comment", noticeId, notice.getCommentCount());
+
+        long totalViewCount = postRedisService.increment("notice", "totalView", noticeId);
+        long likeCount = postRedisService.getCount("notice", "like", noticeId);
+        long commentCount = postRedisService.getCount("notice", "comment", noticeId);
+
         NoticeFileGroups noticeFileGroups = noticeFileService.getNoticeFileGroups(notice);
-        return NoticeInfoResponseDTO.from(notice, noticeLikeService.userIsLiked(noticeId, userId), noticeFileGroups.files(), noticeFileGroups.images());
+        return NoticeInfoResponseDTO.from(notice, noticeLikeService.userIsLiked(noticeId, userId), likeCount, commentCount, noticeFileGroups.files(), noticeFileGroups.images());
     }
 
     @Transactional

--- a/src/main/java/com/real/backend/domain/notice/service/NoticeService.java
+++ b/src/main/java/com/real/backend/domain/notice/service/NoticeService.java
@@ -149,6 +149,7 @@ public class NoticeService {
         noticeRepository.save(notice);
     }
 
+    // TODO 생성 날짜 지정 관련 버그 수정
     @Transactional
     public void pasteNoticeTmp(NoticePasteRequestDTO noticeCreateRequestDTO, List<MultipartFile> images,
         List<MultipartFile> files) throws JsonProcessingException {

--- a/src/main/java/com/real/backend/infra/redis/PostRedisService.java
+++ b/src/main/java/com/real/backend/infra/redis/PostRedisService.java
@@ -30,6 +30,10 @@ public class PostRedisService {
         return redisTemplate.opsForValue().increment(buildKey(domain, type, id));
     }
 
+    public Long decrement(String domain, String type, Long id) {
+        return redisTemplate.opsForValue().decrement(buildKey(domain, type, id));
+    }
+
     public Long getCount(String domain, String type, Long id) {
         Object val = redisTemplate.opsForValue().get(buildKey(domain, type, id));
         return val == null ? 0L : Long.parseLong(val.toString());

--- a/src/main/java/com/real/backend/infra/redis/PostRedisService.java
+++ b/src/main/java/com/real/backend/infra/redis/PostRedisService.java
@@ -1,0 +1,38 @@
+package com.real.backend.infra.redis;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class PostRedisService {
+
+    private final RedisTemplate<Object, Object> redisTemplate;
+
+    private String buildKey(String domain, String type, Long id) {
+        return domain + ":" + type + ":" + id;  // ex) news:view:12
+    }
+
+    public void initCount(String domain, String type, Long id, Long value) {
+        String key = buildKey(domain, type, id);
+        if (!redisTemplate.hasKey(key)) {
+            redisTemplate.opsForValue().set(key, value);
+        }
+    }
+
+    public Long increment(String domain, String type, Long id) {
+        return redisTemplate.opsForValue().increment(buildKey(domain, type, id));
+    }
+
+    public Long getCount(String domain, String type, Long id) {
+        Object val = redisTemplate.opsForValue().get(buildKey(domain, type, id));
+        return val == null ? 0L : Long.parseLong(val.toString());
+    }
+
+    public void delete(String domain, String type, Long id) {
+        redisTemplate.delete(buildKey(domain, type, id));
+    }
+
+}

--- a/src/main/java/com/real/backend/infra/redis/PostRedisService.java
+++ b/src/main/java/com/real/backend/infra/redis/PostRedisService.java
@@ -1,5 +1,9 @@
 package com.real.backend.infra.redis;
 
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
@@ -9,7 +13,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class PostRedisService {
 
-    private final RedisTemplate<Object, Object> redisTemplate;
+    private final RedisTemplate<String, Object> redisTemplate;
 
     private String buildKey(String domain, String type, Long id) {
         return domain + ":" + type + ":" + id;  // ex) news:view:12
@@ -35,4 +39,13 @@ public class PostRedisService {
         redisTemplate.delete(buildKey(domain, type, id));
     }
 
+    public List<Long> getIds(String domain, String type) {
+        String str = domain + ":" + type + ":*";
+
+        Set<String> keys = redisTemplate.keys(str);
+        return keys.stream()
+            .map(k -> (k.substring((domain+":"+type+":").length())))
+            .map(Long::parseLong)
+            .collect(Collectors.toList());
+    }
 }

--- a/src/main/java/com/real/backend/post/Post.java
+++ b/src/main/java/com/real/backend/post/Post.java
@@ -42,7 +42,6 @@ public abstract class Post extends BaseEntity {
 
     public void increaseLikesCount() {this.likeCount++;}
     public void decreaseLikesCount() {this.likeCount--;}
-    public void increaseCommentCount() {this.commentCount++;}
     public void decreaseCommentCount() {this.commentCount--;}
 
     public void updatePost(String title, String content, String tag) {

--- a/src/main/java/com/real/backend/post/Post.java
+++ b/src/main/java/com/real/backend/post/Post.java
@@ -40,7 +40,6 @@ public abstract class Post extends BaseEntity {
     @Column(nullable = false, columnDefinition = "INT UNSIGNED")
     private Long commentCount;
 
-    public void increaseTotalViewCount() {this.totalViewCount++;}
     public void increaseLikesCount() {this.likeCount++;}
     public void decreaseLikesCount() {this.likeCount--;}
     public void increaseCommentCount() {this.commentCount++;}


### PR DESCRIPTION
### Description

<!--
  간단하게 PR의 목적을 설명하세요.
  이 PR이 해결하려는 문제나 추가하려는 기능에 대해 요약해주세요.
-->

공지 생성시 날짜 반영 안되는 버그 수정

### Related Issues

<!--
  관련된 이슈 번호를 참고하세요.
  예: Fixes #123, Closes #456
-->
- Resolves #101 

### Changes Made

<!--
  이 PR에서 변경된 사항을 설명하세요.
  코드, 문서, 설정 등 변경된 내용을 상세히 기술합니다.
-->

1. enitty.save할 때 createdAt이 처음 save된 날짜로 덮어 쓰기 때문에 createdAt을 update하고 다시 save하는 방식으로 수정

### Screenshots or Video

<!--
  변경된 사항이 UI에 영향을 미치는 경우, 변경 전후의 스크린샷이나 동영상을 첨부하세요.
-->

### Testing

<!--
  변경 사항을 테스트한 방법을 설명하세요.
  테스트한 환경 (OS, 브라우저, 장치 등)과 테스트 절차를 구체적으로 기술합니다.
-->

### Checklist

<!--
  PR 작성 시 다음 항목들을 확인하세요.
-->

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 모든 테스트가 성공적으로 통과했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.
- [x] 코드 리뷰어를 지정했습니다.

### Additional Notes

<!--
  리뷰어가 이해하는 데 도움이 될 추가적인 참고 사항이나 정보가 있다면 여기에 작성하세요.
-->

