### PR TITLE
✨ feat: 위키 페이지네이션 방식 변경

### DIFF
--- a/src/main/java/com/real/backend/infra/redis/loader/WikiLoader.java
+++ b/src/main/java/com/real/backend/infra/redis/loader/WikiLoader.java
@@ -15,6 +15,6 @@ public class WikiLoader implements ApplicationRunner {
 
     @Override
     public void run(ApplicationArguments args) {
-        wikiRedisService.loadAllWikisToRedis();
+        wikiRedisService.loadAllWikiDataToRedis();
     }
 }

--- a/src/main/java/com/real/backend/modules/wiki/dto/WikiListResponseDTO.java
+++ b/src/main/java/com/real/backend/modules/wiki/dto/WikiListResponseDTO.java
@@ -31,8 +31,4 @@ public class WikiListResponseDTO {
             .updatedAt(updatedAt)
             .build();
     }
-
-    public void updateUpdatedAt(LocalDateTime updatedAt) {
-        this.updatedAt = updatedAt;
-    }
 }

--- a/src/main/java/com/real/backend/modules/wiki/repository/WikiRepository.java
+++ b/src/main/java/com/real/backend/modules/wiki/repository/WikiRepository.java
@@ -4,8 +4,6 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -24,45 +22,6 @@ WHERE w.deletedAt IS NULL
 """)
     List<Long> getAllId();
 
-    @Query("""
-        SELECT w FROM Wiki w
-        WHERE  w.deletedAt IS NULL
-        ORDER  BY w.updatedAt DESC, w.id DESC
-        """)
-    Slice<Wiki> fetchLatestFirst(Pageable pg);   // 첫 페이지
-
-    @Query("""
-        SELECT w FROM Wiki w
-        WHERE  w.deletedAt IS NULL
-        AND ( w.updatedAt < :uAt
-                OR (w.updatedAt = :uAt AND w.id < :id) )
-        ORDER BY w.updatedAt DESC, w.id DESC
-        """)
-    Slice<Wiki> fetchLatest(
-        @Param("id") Long id,
-        Pageable pg,
-        @Param("uAt") LocalDateTime uAt);
-
-    /* 이름순 ------------------------------------------------------------ */
-    @Query("""
-        SELECT w FROM Wiki w
-        WHERE  w.deletedAt IS NULL
-        AND w.title LIKE %:keyword%
-        ORDER BY w.title ASC
-        """)
-    Slice<Wiki> fetchTitleFirst(Pageable pg, @Param("keyword") String keyword);
-
-    @Query("""
-        SELECT w FROM Wiki w
-        WHERE w.title LIKE %:keyword%
-        AND w.id > :id
-        AND w.deletedAt IS NULL
-        ORDER BY w.title ASC
-        """)
-    Slice<Wiki> fetchTitle(@Param("keyword") String keyword,
-        @Param("id")    Long id,
-        Pageable pg);
-
     @Query(value = """
     SELECT id FROM wiki
     ORDER BY updated_at DESC
@@ -78,4 +37,7 @@ WHERE w.deletedAt IS NULL
 
     @Query(value = "SELECT * from wiki WHERE deleted_at IS NULL",nativeQuery = true)
     List<Wiki> findAllWithoutDeleted();
+
+    @Query(value = "SELECT w.updatedAt FROM Wiki w WHERE w.id = :id")
+    LocalDateTime getWikiUpdatedAtById(@Param("id") Long id);
 }

--- a/src/main/java/com/real/backend/modules/wiki/service/WikiCursorPaginationService.java
+++ b/src/main/java/com/real/backend/modules/wiki/service/WikiCursorPaginationService.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -84,6 +85,9 @@ public class WikiCursorPaginationService {
     }
 
     public SliceDTO<WikiListResponseDTO> getWikiListWithTitle(int limit, String cursorStandard, String keyword) {
+        if (Objects.equals(keyword, " ") || Objects.equals(keyword, "") || keyword == null) {
+            throw new BadRequestException("빈 문자열은 입력으로 들어올 수 없습니다.");
+        }
         boolean isFirstPage = (cursorStandard == null);
 
         ZSetOperations<String, String> zSetOps = redisTemplate.opsForZSet();

--- a/src/main/java/com/real/backend/modules/wiki/service/WikiCursorPaginationService.java
+++ b/src/main/java/com/real/backend/modules/wiki/service/WikiCursorPaginationService.java
@@ -4,7 +4,6 @@ import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -14,12 +13,12 @@ import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.stereotype.Service;
 
 import com.real.backend.common.exception.BadRequestException;
-import com.real.backend.common.exception.NotFoundException;
 import com.real.backend.common.util.CursorUtils;
 import com.real.backend.common.util.dto.SliceDTO;
 import com.real.backend.modules.wiki.domain.SortBy;
 import com.real.backend.modules.wiki.dto.WikiListResponseDTO;
 import com.real.backend.modules.wiki.dto.WikiTitleCursor;
+import com.real.backend.modules.wiki.repository.WikiRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -27,37 +26,81 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class WikiCursorPaginationService {
 
-    private static final String SORTED_KEY = "wikis:sorted:latest";
+    private static final String SORTED_KEY_LATEST = "wikis:sorted:latest";
+    private static final String SORTED_KEY_TITLE = "wikis:sorted:title";
+
     private final StringRedisTemplate redisTemplate;
+    private final WikiRepository wikiRepository;
 
     public SliceDTO<WikiListResponseDTO> getWikiListByCursor(Long cursorId, int limit, String cursorStandard, SortBy sort, String keyword){
         if (sort == SortBy.LATEST){
             return getWikiListWithLatest(limit, cursorStandard);
         } else if (sort == SortBy.TITLE) {
-            return searchWikiByTitleKeyword(keyword, cursorStandard, limit);
+            return getWikiListWithTitle(limit, cursorStandard, keyword);
         } else {
             throw new BadRequestException("정렬 기준이 잘 못 들어왔습니다.");
         }
     }
 
-    public SliceDTO<WikiListResponseDTO> searchWikiByTitleKeyword(String keyword, String cursorStandard, int limit) {
-        boolean isFirstPage = (cursorStandard == null);
-        ZSetOperations<String, String> zSetOps = redisTemplate.opsForZSet();
-        String redisKey = "wikis:title:index";
+    public SliceDTO<WikiListResponseDTO> getWikiListWithLatest(int limit, String cursorStandard) {
+        double maxScore = (cursorStandard == null)
+            ? Double.POSITIVE_INFINITY
+            : LocalDateTime.parse(cursorStandard).toEpochSecond(ZoneOffset.UTC);
 
-        Set<String> allTitles = zSetOps.range(redisKey, 0, -1); // 전체 range
+        long offset = (cursorStandard == null) ? 0 : 1;
 
-        if (allTitles == null || allTitles.isEmpty()) {
+        Set<ZSetOperations.TypedTuple<String>> tuples = redisTemplate.opsForZSet()
+            .reverseRangeByScoreWithScores(
+                SORTED_KEY_LATEST,
+                Double.NEGATIVE_INFINITY,
+                maxScore,
+                offset,
+                limit + 1);
+
+        if (tuples == null || tuples.isEmpty()) {
             return CursorUtils.toCursorDto(
                 List.of(), limit,
-                this::mapToDto,
-                WikiTitleCursor::getTitle,
-                WikiTitleCursor::getId,
+                Function.identity(),
+                dto -> dto.getUpdatedAt().toString(),
+                WikiListResponseDTO::getId,
+                SliceDTO::of);
+        }
+
+        List<WikiListResponseDTO> dtos = tuples.stream().map(tuple -> {
+            Long id = Long.valueOf(tuple.getValue());
+            String title = wikiRepository.getWikiTitleById(id);
+            LocalDateTime updatedAt = LocalDateTime.ofEpochSecond(tuple.getScore().longValue(), 0, ZoneOffset.UTC);
+            return WikiListResponseDTO.from(id, title, updatedAt);
+        }).collect(Collectors.toList());
+
+        return CursorUtils.toCursorDto(
+            dtos,
+            limit,
+            Function.identity(),
+            dto -> dto.getUpdatedAt().toString(),
+            WikiListResponseDTO::getId,
+            SliceDTO::of
+        );
+    }
+
+    public SliceDTO<WikiListResponseDTO> getWikiListWithTitle(int limit, String cursorStandard, String keyword) {
+        boolean isFirstPage = (cursorStandard == null);
+
+        ZSetOperations<String, String> zSetOps = redisTemplate.opsForZSet();
+        Set<String> results = zSetOps.range(SORTED_KEY_TITLE, 0, -1);
+
+        if (results == null || results.isEmpty()) {
+            return CursorUtils.toCursorDto(
+                List.of(),
+                limit,
+                this::mapToDtoByTitleZSet,
+                WikiListResponseDTO::getTitle,
+                WikiListResponseDTO::getId,
                 SliceDTO::of
             );
         }
 
-        List<WikiTitleCursor> filtered = allTitles.stream()
+        List<WikiTitleCursor> filtered = results.stream()
             .map(val -> {
                 String[] parts = val.split(":");
                 return new WikiTitleCursor(parts[0], Long.valueOf(parts[1]));
@@ -76,56 +119,14 @@ public class WikiCursorPaginationService {
         );
     }
 
-
-    public SliceDTO<WikiListResponseDTO> getWikiListWithLatest(int limit, String cursorStandard) {
-        double maxScore = (cursorStandard == null)
-            ? Double.POSITIVE_INFINITY
-            : LocalDateTime.parse(cursorStandard)
-            .toEpochSecond(ZoneOffset.UTC);
-        long offset = cursorStandard == null ? 0 : 1;
-        Set<ZSetOperations.TypedTuple<String>> tuples = redisTemplate.opsForZSet()
-            .reverseRangeByScoreWithScores(
-                SORTED_KEY,
-                Double.NEGATIVE_INFINITY,
-                maxScore,
-                offset,
-                limit + 1
-            );
-
-        if (tuples == null || tuples.isEmpty()) {
-            throw new NotFoundException("위키 목록을 불러올 수 없습니다.");
-        }
-
-        List<Long> idList = tuples.stream()
-            .map(ZSetOperations.TypedTuple::getValue)
-            .map(Long::valueOf)
-            .collect(Collectors.toList());
-
-        return CursorUtils.toCursorDto(
-            idList,
-            limit,
-            id -> {
-                Map<Object, Object> wikiMap = redisTemplate.opsForHash().entries("wiki:" + id);
-                return WikiListResponseDTO.from(
-                    id,
-                    (String) wikiMap.get("title"),
-                    LocalDateTime.parse((String) wikiMap.get("updated_at"))
-                    );
-            },
-            id -> {
-                Map<Object, Object> wikiMap = redisTemplate.opsForHash().entries("wiki:" + id);
-                return (String) wikiMap.get("updated_at");
-            },
-            Function.identity(),
-            SliceDTO::new
-        );
+    private WikiListResponseDTO mapToDtoByTitleZSet(WikiListResponseDTO dto) {
+        return dto;
     }
 
     private WikiListResponseDTO mapToDto(WikiTitleCursor cursor) {
-        String redisKey = "wiki:" + cursor.getId();
-        String title = redisTemplate.opsForHash().get(redisKey, "title").toString();
-        String updatedAt = redisTemplate.opsForHash().get(redisKey, "updated_at").toString();
+        String title = wikiRepository.getWikiTitleById(cursor.getId());
+        LocalDateTime updatedAt = wikiRepository.getWikiUpdatedAtById(cursor.getId());
 
-        return WikiListResponseDTO.from(cursor.getId(), title, LocalDateTime.parse(updatedAt));
+        return WikiListResponseDTO.from(cursor.getId(), title, updatedAt);
     }
 }

--- a/src/main/java/com/real/backend/modules/wiki/service/WikiService.java
+++ b/src/main/java/com/real/backend/modules/wiki/service/WikiService.java
@@ -2,10 +2,12 @@ package com.real.backend.modules.wiki.service;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Objects;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.real.backend.common.exception.BadRequestException;
 import com.real.backend.common.exception.NotFoundException;
 import com.real.backend.infra.redis.WikiRedisService;
 import com.real.backend.modules.wiki.domain.SearchMethod;
@@ -35,6 +37,9 @@ public class WikiService {
 
     @Transactional(readOnly = true)
     public Wiki getWiki(String title, SearchMethod method) {
+        if (Objects.equals(title, " ") || Objects.equals(title, "")) {
+            throw new BadRequestException("빈 문자열은 입력으로 들어올 수 없습니다.");
+        }
         if (SearchMethod.NORMAL.equals(method)) {
             Wiki wiki = wikiRedisService.getWikiById(title);
             if (wiki == null) {

--- a/src/main/java/com/real/backend/modules/wiki/service/WikiService.java
+++ b/src/main/java/com/real/backend/modules/wiki/service/WikiService.java
@@ -61,6 +61,9 @@ public class WikiService {
     public void deleteWiki(Long wikiId) {
         Wiki wiki = wikiRepository.findById(wikiId).orElseThrow(() -> new NotFoundException("해당 Id를 가진 위키가 존재하지 않습니다."));
         wiki.delete();
+        wikiRedisService.deleteZSetWikiTitle(wikiId, wiki.getTitle());
+        wikiRedisService.deleteZSetWikiUpdatedAt(wikiId);
+        wikiRedisService.deleteWikiHash(wikiId);
         wikiRepository.save(wiki);
     }
 }

--- a/src/main/java/com/real/backend/modules/wiki/service/WikiService.java
+++ b/src/main/java/com/real/backend/modules/wiki/service/WikiService.java
@@ -3,22 +3,15 @@ package com.real.backend.modules.wiki.service;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.real.backend.modules.wiki.domain.SearchMethod;
-import com.real.backend.modules.wiki.domain.SortBy;
-import com.real.backend.modules.wiki.domain.Wiki;
-import com.real.backend.modules.wiki.dto.WikiCreateRequestDTO;
-import com.real.backend.modules.wiki.dto.WikiListResponseDTO;
-import com.real.backend.modules.wiki.repository.WikiRepository;
-import com.real.backend.common.exception.BadRequestException;
 import com.real.backend.common.exception.NotFoundException;
 import com.real.backend.infra.redis.WikiRedisService;
-import com.real.backend.common.util.dto.SliceDTO;
+import com.real.backend.modules.wiki.domain.SearchMethod;
+import com.real.backend.modules.wiki.domain.Wiki;
+import com.real.backend.modules.wiki.dto.WikiCreateRequestDTO;
+import com.real.backend.modules.wiki.repository.WikiRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -59,66 +52,10 @@ public class WikiService {
         return wikiRepository.findById(randomId).orElseThrow(() -> new NotFoundException("해당 id를 가진 위키가 존재하지 않습니다."));
     }
 
-    @Transactional(readOnly = true)
-    public SliceDTO<WikiListResponseDTO> getWikiListByCursor(Long cursorId, int limit, SortBy sort, String keyword, String cursorStandard) {
-        String order = sort.toString().toLowerCase();
-
-        if (!order.equals("latest") && !order.equals("title")) {
-            throw new BadRequestException("sort 파라미터는 latest 또는 title 이어야 합니다.");
-        }
-
-        if (keyword != null && keyword.trim().isEmpty()) {
-            throw new BadRequestException("keyword는 빈 문자열이 들어올 수 없습니다.");
-        }
-
-        Pageable pg = PageRequest.of(0, limit);
-        boolean firstPage = (cursorId == null);
-
-        Slice<Wiki> slice = switch (sort) {
-            case LATEST -> firstPage
-                ? wikiRepository.fetchLatestFirst(pg)
-                : wikiRepository.fetchLatest(cursorId, pg, LocalDateTime.parse(cursorStandard));
-
-            case TITLE -> firstPage
-                ? wikiRepository.fetchTitleFirst(pg, keyword)
-                : wikiRepository.fetchTitle(keyword, cursorId, pg);
-        };
-
-        List<Wiki> content = slice.getContent();
-        boolean hasNext = slice.hasNext();
-        List<Wiki> pageItems = content.size() > limit ? content.subList(0, limit) : content;
-
-        // 다음 커서 계산
-        String nextCursorStandard = null;
-        Long nextCursorId = null;
-        if (hasNext) {
-            Wiki last = pageItems.get(pageItems.size() - 1);
-            nextCursorId = last.getId();
-            nextCursorStandard = order.equals("latest")
-                ? last.getUpdatedAt().toString()
-                : null;
-        }
-
-        List<WikiListResponseDTO> dtoList = pageItems.stream()
-            .map(WikiListResponseDTO::of)
-            .map(this::updateUpdatedAt)
-            .toList();
-
-        return new SliceDTO<>(dtoList, nextCursorStandard, nextCursorId, hasNext);
-    }
-
     @Transactional
     public void deleteWiki(Long wikiId) {
         Wiki wiki = wikiRepository.findById(wikiId).orElseThrow(() -> new NotFoundException("해당 Id를 가진 위키가 존재하지 않습니다."));
         wiki.delete();
         wikiRepository.save(wiki);
-    }
-
-    public WikiListResponseDTO updateUpdatedAt(WikiListResponseDTO wikiListResponseDTO) {
-        String updateAt = wikiRedisService.getUpdatedAtByWikiId(wikiListResponseDTO.getId());
-        if (updateAt != null) {
-            wikiListResponseDTO.updateUpdatedAt(LocalDateTime.parse(updateAt));
-        }
-        return wikiListResponseDTO;
     }
 }


### PR DESCRIPTION
### Description

<!--
  간단하게 PR의 목적을 설명하세요.
  이 PR이 해결하려는 문제나 추가하려는 기능에 대해 요약해주세요.
-->

기존: redis에 모든 데이터를 올리고 redis에서 페이지네이션을 함
수정: redis에는 커서의 기준이 되는 값(updatedAt, title)만을 ZSet으로 정렬하게 수정

### Related Issues

<!--
  관련된 이슈 번호를 참고하세요.
  예: Fixes #123, Closes #456
-->
- Resolves #196 

### Changes Made

<!--
  이 PR에서 변경된 사항을 설명하세요.
  코드, 문서, 설정 등 변경된 내용을 상세히 기술합니다.
-->

1. 더 이상 redis에 모든 위키 데이터를 저장하지 않음.
2. 30분 이내에 편집된 위키의 데이터만 저장함.
3. 스프링 시작시 redis에 ZSet으로 정렬된 데이터에 없는 위키만 추가함
4. 검색에 빈 문자열을 허용하지 않도록 수정
5. 위키 삭제시 redis에 있는 데이터도 삭제

### Checklist

<!--
  PR 작성 시 다음 항목들을 확인하세요.
-->

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 모든 테스트가 성공적으로 통과했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.
- [x] 코드 리뷰어를 지정했습니다.

