### PR TITLE
🐛bug: 위키 flush 성공해도 재실패 warning 뜨는 버그 수정

### DIFF
--- a/src/main/java/com/real/backend/modules/wiki/service/WikiSyncService.java
+++ b/src/main/java/com/real/backend/modules/wiki/service/WikiSyncService.java
@@ -49,6 +49,7 @@ public class WikiSyncService {
             for (Long wikiId : failedIds) {
                 try {
                     wikiRedisService.flushToDB(wikiId);
+                    stillFailed.remove(wikiId);
                 } catch (Exception e) {
                     stillFailed.add(wikiId);
                     log.warn("{}차 flush 재시도 실패 - wikiId: {}", attempt + 1, wikiId, e);


### PR DESCRIPTION
### Description

<!--
  간단하게 PR의 목적을 설명하세요.
  이 PR이 해결하려는 문제나 추가하려는 기능에 대해 요약해주세요.
-->

위키 flush 성공해도 재실패 warning 뜨는 버그 수정

### Related Issues

<!--
  관련된 이슈 번호를 참고하세요.
  예: Fixes #123, Closes #456
-->
- Resolves #215 

### Changes Made

<!--
  이 PR에서 변경된 사항을 설명하세요.
  코드, 문서, 설정 등 변경된 내용을 상세히 기술합니다.
-->

1. stillFailed.remove(wikiId) 추가

### Checklist

<!--
  PR 작성 시 다음 항목들을 확인하세요.
-->

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 모든 테스트가 성공적으로 통과했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.
- [x] 코드 리뷰어를 지정했습니다.

### Additional Notes

<!--
  리뷰어가 이해하는 데 도움이 될 추가적인 참고 사항이나 정보가 있다면 여기에 작성하세요.
-->

