### PR TITLE
✨ feat: 알림 기능 SSE 구현

### DIFF
--- a/src/main/java/com/real/backend/batch/SseHeartbeatScheduler.java
+++ b/src/main/java/com/real/backend/batch/SseHeartbeatScheduler.java
@@ -1,0 +1,21 @@
+package com.real.backend.batch;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import com.real.backend.common.util.CONSTANT;
+import com.real.backend.modules.notification.service.NotificationSseService;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class SseHeartbeatScheduler {
+
+    private final NotificationSseService notificationSseService;
+
+    @Scheduled(fixedRate = CONSTANT.HEARTBEAT_INTERVAL)
+    public void heartbeat() {
+        notificationSseService.sendHeartbeat();
+    }
+}

--- a/src/main/java/com/real/backend/common/config/SecurityConfig.java
+++ b/src/main/java/com/real/backend/common/config/SecurityConfig.java
@@ -57,7 +57,7 @@ public class SecurityConfig {
         http
             .authorizeHttpRequests((auth) -> auth
                 .requestMatchers("/api/v1/oauth/**", "/api/v1/news").permitAll()
-                .requestMatchers("/api/v1/auth/**", "api/v2/auth/**").permitAll()
+                .requestMatchers("/api/v1/auth/**", "/api/v2/auth/**").permitAll()
                 .requestMatchers("/error").permitAll()
                 .requestMatchers("/api/healthz").permitAll()    //서버 헬스 체크용 API, Security Filter 우회
                 .requestMatchers("/monitoring-prod/health","/monitoring-prod/info","/monitoring-prod/prometheus").permitAll() // 모니터링 API, Security Filter 우회

--- a/src/main/java/com/real/backend/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/real/backend/common/exception/GlobalExceptionHandler.java
@@ -134,6 +134,6 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(AsyncRequestTimeoutException.class)
     public void handleAsyncRequestTimeoutException(AsyncRequestTimeoutException e) {
-        log.info(e.getMessage());
+        log.warn("SSE 연결 시간이 너무 짧습니다. - " + e.getMessage());
     }
 }

--- a/src/main/java/com/real/backend/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/real/backend/common/exception/GlobalExceptionHandler.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.async.AsyncRequestTimeoutException;
 import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.method.annotation.HandlerMethodValidationException;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
@@ -129,5 +130,10 @@ public class GlobalExceptionHandler {
         return ResponseEntity
             .status(HttpStatus.BAD_REQUEST)
             .body(StatusResponse.of(400, "파라미터 혹은 리소스 속성 값이 제한 설정을 초과했습니다."));
+    }
+
+    @ExceptionHandler(AsyncRequestTimeoutException.class)
+    public void handleAsyncRequestTimeoutException(AsyncRequestTimeoutException e) {
+        log.info(e.getMessage());
     }
 }

--- a/src/main/java/com/real/backend/common/interceptor/ApiAccessInterceptor.java
+++ b/src/main/java/com/real/backend/common/interceptor/ApiAccessInterceptor.java
@@ -7,6 +7,7 @@ import org.springframework.web.servlet.HandlerInterceptor;
 
 import com.real.backend.security.JwtUtils;
 
+import jakarta.servlet.DispatcherType;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -21,6 +22,10 @@ public class ApiAccessInterceptor implements HandlerInterceptor {
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
         String uri = request.getRequestURI();
+        if (request.getDispatcherType() == DispatcherType.ASYNC) {
+            return true;
+        }
+
         if (!uri.startsWith("/api/") || uri.startsWith("/api/v1/auth/") || uri.startsWith("/api/v2/auth/") || uri.startsWith("/api/v1/oauth/")
             || uri.startsWith("/api/v1/news/")) return true;
 

--- a/src/main/java/com/real/backend/common/util/CONSTANT.java
+++ b/src/main/java/com/real/backend/common/util/CONSTANT.java
@@ -8,4 +8,8 @@ public class CONSTANT {
     public static final long ACCESS_TOKEN_EXPIRED = 5 * 60L; // 5분
     public static final long REFRESH_TOKEN_EXPIRED = 14 * 24 * 60 * 60L; // 14일
 
+    // SSE connection time
+    public static final long CONNECTION_TIMEOUT = 5 * 60 * 1000L; // 5분
+    public static final long HEARTBEAT_INTERVAL = 10 * 1000L; // 10초
+
 }

--- a/src/main/java/com/real/backend/common/util/CONSTANT.java
+++ b/src/main/java/com/real/backend/common/util/CONSTANT.java
@@ -5,7 +5,7 @@ public class CONSTANT {
     private CONSTANT() {}
 
     // JWT Expire time
-    public static final long ACCESS_TOKEN_EXPIRED = 60 * 60L; // 1시간
+    public static final long ACCESS_TOKEN_EXPIRED = 5 * 60L; // 5분
     public static final long REFRESH_TOKEN_EXPIRED = 14 * 24 * 60 * 60L; // 14일
 
 }

--- a/src/main/java/com/real/backend/infra/sse/repository/SseEmitterRepository.java
+++ b/src/main/java/com/real/backend/infra/sse/repository/SseEmitterRepository.java
@@ -1,0 +1,36 @@
+package com.real.backend.infra.sse.repository;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.springframework.stereotype.Repository;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Repository
+public class SseEmitterRepository {
+    private final Map<Long, Map<String, SseEmitter>> emitters = new ConcurrentHashMap<>();
+
+    public SseEmitter save(Long userId, String emitterId, SseEmitter emitter) {
+        emitters.computeIfAbsent(userId, k -> new ConcurrentHashMap<>())
+            .put(emitterId, emitter);
+        return emitter;
+    }
+
+    public Map<String, SseEmitter> get(Long userId) {
+        return emitters.get(userId);
+    }
+
+    public void delete(Long userId, String emitterId) {
+        Map<String, SseEmitter> userEmitters = emitters.get(userId);
+        if (userEmitters != null) {
+            userEmitters.remove(emitterId);
+            if (userEmitters.isEmpty()) {
+                emitters.remove(userId);
+            }
+        }
+    }
+
+    public Map<Long, Map<String, SseEmitter>> findAllEmitters() {
+        return emitters;
+    }
+}

--- a/src/main/java/com/real/backend/infra/sse/repository/SseEmitterRepository.java
+++ b/src/main/java/com/real/backend/infra/sse/repository/SseEmitterRepository.java
@@ -8,29 +8,23 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @Repository
 public class SseEmitterRepository {
-    private final Map<Long, Map<String, SseEmitter>> emitters = new ConcurrentHashMap<>();
 
-    public SseEmitter save(Long userId, String emitterId, SseEmitter emitter) {
-        emitters.computeIfAbsent(userId, k -> new ConcurrentHashMap<>())
-            .put(emitterId, emitter);
+    private final Map<Long, SseEmitter> emitters = new ConcurrentHashMap<>();
+
+    public SseEmitter save(Long userId, SseEmitter emitter) {
+        emitters.put(userId, emitter);
         return emitter;
     }
 
-    public Map<String, SseEmitter> get(Long userId) {
+    public SseEmitter get(Long userId) {
         return emitters.get(userId);
     }
 
-    public void delete(Long userId, String emitterId) {
-        Map<String, SseEmitter> userEmitters = emitters.get(userId);
-        if (userEmitters != null) {
-            userEmitters.remove(emitterId);
-            if (userEmitters.isEmpty()) {
-                emitters.remove(userId);
-            }
-        }
+    public void delete(Long userId) {
+        emitters.remove(userId);
     }
 
-    public Map<Long, Map<String, SseEmitter>> findAllEmitters() {
+    public Map<Long, SseEmitter> findAllEmitters() {
         return emitters;
     }
 }

--- a/src/main/java/com/real/backend/infra/sse/service/SseEmitterService.java
+++ b/src/main/java/com/real/backend/infra/sse/service/SseEmitterService.java
@@ -1,0 +1,20 @@
+package com.real.backend.infra.sse.service;
+
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class SseEmitterService {
+
+    public Long parseLastEventId(String lastEventIdHeader) {
+        long lastEventId = 0L;
+        if (lastEventIdHeader != null) {
+            try {
+                lastEventId = Long.parseLong(lastEventIdHeader);
+            } catch (NumberFormatException ignored) {}
+        }
+        return lastEventId;
+    }
+}

--- a/src/main/java/com/real/backend/modules/auth/controller/AuthController.java
+++ b/src/main/java/com/real/backend/modules/auth/controller/AuthController.java
@@ -13,6 +13,8 @@ import com.real.backend.common.util.CookieUtils;
 import com.real.backend.modules.auth.dto.TokenDTO;
 import com.real.backend.modules.auth.kakao.KakaoUtil;
 import com.real.backend.modules.auth.service.TokenService;
+import com.real.backend.security.CurrentSession;
+import com.real.backend.security.Session;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -33,14 +35,15 @@ public class AuthController {
         }
     }
 
-    @PostMapping("/v1/auth/logout")
-    public StatusResponse logout(HttpServletRequest request, HttpServletResponse response) {
+    @PostMapping("/v2/logout")
+    public StatusResponse logout(HttpServletRequest request, HttpServletResponse response, @CurrentSession Session session) {
         tokenService.deleteRefreshToken(cookieUtils.resolveTokenFromCookie(request, "REFRESH_TOKEN"));
+        notificationSseService.disconnect(session.getId());
         cookieUtils.deleteTokenCookies(response);
         return StatusResponse.of(204, "성공적으로 로그아웃 됐습니다.");
     }
 
-    @PostMapping("v1/auth/refresh")
+    @PostMapping("/v1/auth/refresh")
     public StatusResponse refresh(HttpServletRequest request, HttpServletResponse response) {
         TokenDTO tokenDTO = tokenService.refreshAccessToken(cookieUtils.resolveTokenFromCookie(request, "REFRESH_TOKEN"));
         cookieUtils.setTokenCookies(response, tokenDTO.accessToken(), tokenDTO.refreshToken());

--- a/src/main/java/com/real/backend/modules/auth/controller/AuthController.java
+++ b/src/main/java/com/real/backend/modules/auth/controller/AuthController.java
@@ -14,8 +14,7 @@ import com.real.backend.modules.auth.dto.TokenDTO;
 import com.real.backend.modules.auth.kakao.KakaoUtil;
 import com.real.backend.modules.auth.service.TokenService;
 import com.real.backend.modules.notification.service.NotificationSseService;
-import com.real.backend.security.CurrentSession;
-import com.real.backend.security.Session;
+import com.real.backend.security.JwtUtils;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -29,6 +28,7 @@ public class AuthController {
     private final CookieUtils cookieUtils;
     private final TokenService tokenService;
     private final NotificationSseService notificationSseService;
+    private final JwtUtils jwtUtils;
 
     @GetMapping("/v1/oauth/{provider}")
     public void oauthLogin(@PathVariable("provider") String provider, HttpServletResponse response) throws IOException {
@@ -37,10 +37,10 @@ public class AuthController {
         }
     }
 
-    @PostMapping("/v2/logout")
-    public StatusResponse logout(HttpServletRequest request, HttpServletResponse response, @CurrentSession Session session) {
+    @PostMapping("/v1/auth/logout")
+    public StatusResponse logout(HttpServletRequest request, HttpServletResponse response) {
         tokenService.deleteRefreshToken(cookieUtils.resolveTokenFromCookie(request, "REFRESH_TOKEN"));
-        notificationSseService.disconnect(session.getId());
+        notificationSseService.disconnect(jwtUtils.getId(cookieUtils.resolveTokenFromCookie(request, "ACCESS_TOKEN")));
         cookieUtils.deleteTokenCookies(response);
         return StatusResponse.of(204, "성공적으로 로그아웃 됐습니다.");
     }

--- a/src/main/java/com/real/backend/modules/auth/controller/AuthController.java
+++ b/src/main/java/com/real/backend/modules/auth/controller/AuthController.java
@@ -13,6 +13,7 @@ import com.real.backend.common.util.CookieUtils;
 import com.real.backend.modules.auth.dto.TokenDTO;
 import com.real.backend.modules.auth.kakao.KakaoUtil;
 import com.real.backend.modules.auth.service.TokenService;
+import com.real.backend.modules.notification.service.NotificationSseService;
 import com.real.backend.security.CurrentSession;
 import com.real.backend.security.Session;
 
@@ -27,6 +28,7 @@ public class AuthController {
     private final KakaoUtil kakaoUtil;
     private final CookieUtils cookieUtils;
     private final TokenService tokenService;
+    private final NotificationSseService notificationSseService;
 
     @GetMapping("/v1/oauth/{provider}")
     public void oauthLogin(@PathVariable("provider") String provider, HttpServletResponse response) throws IOException {

--- a/src/main/java/com/real/backend/modules/notice/controller/NoticeController.java
+++ b/src/main/java/com/real/backend/modules/notice/controller/NoticeController.java
@@ -19,10 +19,12 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.real.backend.common.response.DataResponse;
 import com.real.backend.common.response.StatusResponse;
 import com.real.backend.common.util.dto.SliceDTO;
+import com.real.backend.modules.notice.domain.Notice;
+import com.real.backend.modules.notice.dto.NoticeCreateRequestDTO;
 import com.real.backend.modules.notice.dto.NoticeInfoResponseDTO;
 import com.real.backend.modules.notice.dto.NoticeListResponseDTO;
-import com.real.backend.modules.notice.dto.NoticeCreateRequestDTO;
 import com.real.backend.modules.notice.service.NoticeService;
+import com.real.backend.modules.notification.service.NotificationSseService;
 import com.real.backend.modules.user.service.UserNoticeService;
 import com.real.backend.security.CurrentSession;
 import com.real.backend.security.Session;
@@ -36,6 +38,7 @@ import lombok.RequiredArgsConstructor;
 public class NoticeController {
     private final UserNoticeService userNoticeService;
     private final NoticeService noticeService;
+    private final NotificationSseService notificationSseService;
 
     @PreAuthorize("!hasAnyAuthority('OUTSIDER')")
     @GetMapping("/v1/notices")
@@ -90,7 +93,8 @@ public class NoticeController {
         @RequestPart(value = "images", required = false) List<MultipartFile> images,
         @RequestPart(value = "files", required = false) List<MultipartFile> files
     ) throws JsonProcessingException {
-        noticeService.createNotice(noticeCreateRequestDTO, images, files);
+        Notice notice = noticeService.createNotice(noticeCreateRequestDTO, images, files);
+        notificationSseService.sendNoticeNotification(notice);
         return StatusResponse.of(201, "공지가 성공적으로 생성되었습니다.");
     }
 }

--- a/src/main/java/com/real/backend/modules/notice/repository/NoticeRepository.java
+++ b/src/main/java/com/real/backend/modules/notice/repository/NoticeRepository.java
@@ -98,4 +98,6 @@ public interface NoticeRepository extends JpaRepository<Notice, Long> {
 
     @Query("select n.id from Notice n")
     List<Long> findAllNoticeIds();
+
+    List<Notice> findByIdGreaterThanOrderByIdAsc(Long idIsGreaterThan);
 }

--- a/src/main/java/com/real/backend/modules/notice/service/NoticeService.java
+++ b/src/main/java/com/real/backend/modules/notice/service/NoticeService.java
@@ -106,7 +106,7 @@ public class NoticeService {
     }
 
     @Transactional
-    public void createNotice(NoticeCreateRequestDTO noticeCreateRequestDTO, List<MultipartFile> images,
+    public Notice createNotice(NoticeCreateRequestDTO noticeCreateRequestDTO, List<MultipartFile> images,
         List<MultipartFile> files) throws JsonProcessingException {
 
         String userName = noticeCreateRequestDTO.getUserName();
@@ -131,9 +131,9 @@ public class NoticeService {
 
         noticeRepository.save(notice);
         notice.updateCreatedAt(noticeCreateRequestDTO.getCreatedAt());
-        noticeRepository.save(notice);
 
         noticeFileService.uploadFilesToS3(images, notice, true);
         noticeFileService.uploadFilesToS3(files, notice, false);
+        return noticeRepository.save(notice);
     }
 }

--- a/src/main/java/com/real/backend/modules/notification/controller/NotificationSseController.java
+++ b/src/main/java/com/real/backend/modules/notification/controller/NotificationSseController.java
@@ -1,6 +1,7 @@
 package com.real.backend.modules.notification.controller;
 
 import org.springframework.http.MediaType;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -22,6 +23,7 @@ public class NotificationSseController {
 
     private final NotificationSseService notificationSseService;
 
+    @PreAuthorize("!hasAnyAuthority('OUTSIDER')")
     @GetMapping(value="/v1/connect/notification", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public SseEmitter connect(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse, @CurrentSession Session session) {
         SecurityContextUtil.propagateSecurityContextToRequest(httpServletRequest, httpServletResponse);

--- a/src/main/java/com/real/backend/modules/notification/controller/NotificationSseController.java
+++ b/src/main/java/com/real/backend/modules/notification/controller/NotificationSseController.java
@@ -1,0 +1,30 @@
+package com.real.backend.modules.notification.controller;
+
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import com.real.backend.modules.notification.service.NotificationSseService;
+import com.real.backend.security.CurrentSession;
+import com.real.backend.security.SecurityContextUtil;
+import com.real.backend.security.Session;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class NotificationSseController {
+
+    private final NotificationSseService notificationSseService;
+
+    @GetMapping(value="/v1/connect/notification", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public SseEmitter connect(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse, @CurrentSession Session session) {
+        SecurityContextUtil.propagateSecurityContextToRequest(httpServletRequest, httpServletResponse);
+        return notificationSseService.connect(session.getId());
+    }
+}

--- a/src/main/java/com/real/backend/modules/notification/domain/Notification.java
+++ b/src/main/java/com/real/backend/modules/notification/domain/Notification.java
@@ -14,6 +14,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
@@ -43,5 +44,6 @@ public class Notification extends BaseEntity {
     private String message;
 
     @Column(nullable = false)
+    @Builder.Default
     private boolean isRead = false;
 }

--- a/src/main/java/com/real/backend/modules/notification/domain/Notification.java
+++ b/src/main/java/com/real/backend/modules/notification/domain/Notification.java
@@ -1,0 +1,47 @@
+package com.real.backend.modules.notification.domain;
+
+import com.real.backend.common.base.BaseEntity;
+import com.real.backend.modules.user.domain.User;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@Getter
+@SuperBuilder
+@NoArgsConstructor
+@Table(name = "notification")
+public class Notification extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private NotificationType type;
+
+    @Column(nullable = false)
+    private Long referenceId;
+
+    private String message;
+
+    @Column(nullable = false)
+    private boolean isRead = false;
+}

--- a/src/main/java/com/real/backend/modules/notification/domain/NotificationType.java
+++ b/src/main/java/com/real/backend/modules/notification/domain/NotificationType.java
@@ -1,0 +1,5 @@
+package com.real.backend.modules.notification.domain;
+
+public enum NotificationType {
+    NOTICE_CREATED
+}

--- a/src/main/java/com/real/backend/modules/notification/dto/NotificationResponseDTO.java
+++ b/src/main/java/com/real/backend/modules/notification/dto/NotificationResponseDTO.java
@@ -1,5 +1,6 @@
 package com.real.backend.modules.notification.dto;
 
+import com.real.backend.modules.notification.domain.Notification;
 import com.real.backend.modules.notification.domain.NotificationType;
 
 import lombok.AllArgsConstructor;
@@ -18,4 +19,15 @@ public class NotificationResponseDTO {
     private Long referenceId;
     private String message;
     private boolean isRead;
+
+    public static NotificationResponseDTO from(Notification notification) {
+        return NotificationResponseDTO.builder()
+            .notificationId(notification.getId())
+            .userId(notification.getUser().getId())
+            .type(notification.getType())
+            .referenceId(notification.getReferenceId())
+            .message(notification.getMessage())
+            .isRead(notification.isRead())
+            .build();
+    }
 }

--- a/src/main/java/com/real/backend/modules/notification/dto/NotificationResponseDTO.java
+++ b/src/main/java/com/real/backend/modules/notification/dto/NotificationResponseDTO.java
@@ -1,0 +1,21 @@
+package com.real.backend.modules.notification.dto;
+
+import com.real.backend.modules.notification.domain.NotificationType;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class NotificationResponseDTO {
+    private Long notificationId;
+    private Long userId;
+    private NotificationType type;
+    private Long referenceId;
+    private String message;
+    private boolean isRead;
+}

--- a/src/main/java/com/real/backend/modules/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/real/backend/modules/notification/repository/NotificationRepository.java
@@ -1,5 +1,7 @@
 package com.real.backend.modules.notification.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -8,4 +10,5 @@ import com.real.backend.modules.notification.domain.Notification;
 @Repository
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
 
+    List<Notification> findByUserIdAndIdGreaterThanOrderByIdAsc(Long userId, Long idIsGreaterThan);
 }

--- a/src/main/java/com/real/backend/modules/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/real/backend/modules/notification/repository/NotificationRepository.java
@@ -1,0 +1,11 @@
+package com.real.backend.modules.notification.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.real.backend.modules.notification.domain.Notification;
+
+@Repository
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+}

--- a/src/main/java/com/real/backend/modules/notification/service/NotificationService.java
+++ b/src/main/java/com/real/backend/modules/notification/service/NotificationService.java
@@ -30,7 +30,6 @@ public class NotificationService {
             .type(notificationType)
             .build();
         notificationRepository.save(notification);
-
         notificationSseService.sendNotification(userId, NotificationResponseDTO.from(notification));
     }
 

--- a/src/main/java/com/real/backend/modules/notification/service/NotificationService.java
+++ b/src/main/java/com/real/backend/modules/notification/service/NotificationService.java
@@ -1,0 +1,37 @@
+package com.real.backend.modules.notification.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.real.backend.modules.notification.domain.Notification;
+import com.real.backend.modules.notification.domain.NotificationType;
+import com.real.backend.modules.notification.dto.NotificationResponseDTO;
+import com.real.backend.modules.notification.repository.NotificationRepository;
+import com.real.backend.modules.user.component.UserFinder;
+import com.real.backend.modules.user.domain.User;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+
+    private final UserFinder userFinder;
+    private final NotificationRepository notificationRepository;
+    private final NotificationSseService notificationSseService;
+
+    @Transactional
+    public void createAndSendNotification(Long userId, Long referenceId, NotificationType notificationType, String message) {
+        User user = userFinder.getUser(userId);
+        Notification notification = Notification.builder()
+            .user(user)
+            .referenceId(referenceId)
+            .message(message)
+            .type(notificationType)
+            .build();
+        notificationRepository.save(notification);
+
+        notificationSseService.sendNotification(userId, NotificationResponseDTO.from(notification));
+    }
+
+}

--- a/src/main/java/com/real/backend/modules/notification/service/NotificationSseService.java
+++ b/src/main/java/com/real/backend/modules/notification/service/NotificationSseService.java
@@ -63,16 +63,19 @@ public class NotificationSseService {
     }
 
     public void disconnect(Long userId) {
-        Map<String, SseEmitter> userEmitters = sseEmitterRepository.get(userId);
-        if (userEmitters == null) return;
-        userEmitters.forEach((emitterId, emitter) -> {
-            emitter.complete();
-            sseEmitterRepository.delete(userId, emitterId);
         SseEmitter emitter = sseEmitterRepository.get(userId);
         if (emitter == null) return;
         emitter.complete();
         sseEmitterRepository.delete(userId);
     }
+
+    public void sendHeartbeat() {
+        sseEmitterRepository.findAllEmitters().forEach((userId, emitter) -> {
+            try {
+                emitter.send(SseEmitter.event().comment("heartbeat").data("heartbeat sended"));
+            } catch (IOException e) {
+                sseEmitterRepository.delete(userId);
+            }
         });
     }
 }

--- a/src/main/java/com/real/backend/modules/notification/service/NotificationSseService.java
+++ b/src/main/java/com/real/backend/modules/notification/service/NotificationSseService.java
@@ -1,0 +1,71 @@
+package com.real.backend.modules.notification.service;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import com.real.backend.common.util.CONSTANT;
+import com.real.backend.infra.sse.repository.SseEmitterRepository;
+import com.real.backend.modules.notification.dto.NotificationResponseDTO;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationSseService {
+
+    private final SseEmitterRepository sseEmitterRepository;
+
+    public SseEmitter connect(Long userId) {
+        String emitterId = UUID.randomUUID().toString();
+        SseEmitter sseEmitter = new SseEmitter(CONSTANT.ACCESS_TOKEN_EXPIRED);
+
+        sseEmitter.onCompletion(() -> sseEmitterRepository.delete(userId, emitterId));
+        sseEmitter.onTimeout(() -> sseEmitterRepository.delete(userId, emitterId));
+        sseEmitter.onError((e) -> sseEmitterRepository.delete(userId, emitterId));
+
+        sseEmitterRepository.save(userId, emitterId, sseEmitter);
+
+        try {
+            sseEmitter.send(SseEmitter.event()
+                .name("connect")
+                .data("SSE 연결 성공"));
+        } catch (IOException e) {
+            sseEmitterRepository.delete(userId, emitterId);
+        }
+
+        return sseEmitter;
+    }
+
+    public void sendNotification(Long userId, NotificationResponseDTO notificationResponseDTO) {
+        Map<String, SseEmitter> userEmitters = sseEmitterRepository.get(userId);
+        if (userEmitters == null) return;
+
+        userEmitters.forEach((emitterId, emitter) -> {
+            try {
+                emitter.send(SseEmitter.event()
+                    .name("notification")
+                    .data(notificationResponseDTO));
+            } catch (IOException e) {
+                sseEmitterRepository.delete(userId, emitterId);
+            }
+        });
+    }
+
+    public void sendNotificationToAll(NotificationResponseDTO notificationResponseDTO) {
+        sseEmitterRepository.findAllEmitters().forEach((userId, emitters) -> {
+            emitters.forEach((emitterId, emitter) -> {
+                try {
+                    emitter.send(SseEmitter.event()
+                        .name("notification")
+                        .data(notificationResponseDTO));
+                } catch (IOException e) {
+                    sseEmitterRepository.delete(userId, emitterId);
+                }
+            });
+        });
+    }
+}

--- a/src/main/java/com/real/backend/modules/notification/service/NotificationSseService.java
+++ b/src/main/java/com/real/backend/modules/notification/service/NotificationSseService.java
@@ -7,6 +7,7 @@ import java.util.UUID;
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
+import com.real.backend.common.util.CONSTANT;
 import com.real.backend.infra.sse.repository.SseEmitterRepository;
 import com.real.backend.modules.notification.dto.NotificationResponseDTO;
 
@@ -20,7 +21,7 @@ public class NotificationSseService {
 
     public SseEmitter connect(Long userId) {
         String emitterId = UUID.randomUUID().toString();
-        SseEmitter sseEmitter = new SseEmitter(-1L);
+        SseEmitter sseEmitter = new SseEmitter(CONSTANT.REFRESH_TOKEN_EXPIRED);
 
         sseEmitter.onCompletion(() -> sseEmitterRepository.delete(userId, emitterId));
         sseEmitter.onTimeout(() -> sseEmitterRepository.delete(userId, emitterId));

--- a/src/main/java/com/real/backend/modules/notification/service/NotificationSseService.java
+++ b/src/main/java/com/real/backend/modules/notification/service/NotificationSseService.java
@@ -7,7 +7,6 @@ import java.util.UUID;
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
-import com.real.backend.common.util.CONSTANT;
 import com.real.backend.infra.sse.repository.SseEmitterRepository;
 import com.real.backend.modules.notification.dto.NotificationResponseDTO;
 
@@ -21,7 +20,7 @@ public class NotificationSseService {
 
     public SseEmitter connect(Long userId) {
         String emitterId = UUID.randomUUID().toString();
-        SseEmitter sseEmitter = new SseEmitter(CONSTANT.ACCESS_TOKEN_EXPIRED);
+        SseEmitter sseEmitter = new SseEmitter(-1L);
 
         sseEmitter.onCompletion(() -> sseEmitterRepository.delete(userId, emitterId));
         sseEmitter.onTimeout(() -> sseEmitterRepository.delete(userId, emitterId));
@@ -66,6 +65,15 @@ public class NotificationSseService {
                     sseEmitterRepository.delete(userId, emitterId);
                 }
             });
+        });
+    }
+
+    public void disconnect(Long userId) {
+        Map<String, SseEmitter> userEmitters = sseEmitterRepository.get(userId);
+        if (userEmitters == null) return;
+        userEmitters.forEach((emitterId, emitter) -> {
+            emitter.complete();
+            sseEmitterRepository.delete(userId, emitterId);
         });
     }
 }

--- a/src/main/java/com/real/backend/modules/user/repository/UserRepository.java
+++ b/src/main/java/com/real/backend/modules/user/repository/UserRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import com.real.backend.modules.user.domain.Role;
 import com.real.backend.modules.user.domain.User;
 
 @Repository
@@ -19,4 +20,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     @Query("SELECT u.id FROM User u WHERE u.lastLoginAt >= :since")
     List<Long> findRecentlyActiveUserIds(@Param("since") LocalDateTime since);
+
+    @Query("SELECT u.role FROM User u WHERE u.id = :id")
+    Role findRoleById(@Param("id") Long id);
 }

--- a/src/main/java/com/real/backend/security/SecurityContextUtil.java
+++ b/src/main/java/com/real/backend/security/SecurityContextUtil.java
@@ -1,0 +1,29 @@
+package com.real.backend.security;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.context.RequestAttributeSecurityContextRepository;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+/**
+ * 비동기 컨트롤러에서 인증 정보를 수동으로 전파하기 위한 헬퍼 메서드. DeferredResult, @Async 등에서 SecurityContext가 끊기는 문제를 방지함.
+ */
+public class SecurityContextUtil {
+
+    public static void propagateSecurityContextToRequest(
+        HttpServletRequest req, HttpServletResponse res) {
+        // 현재 스레드의 SecurityContext에서 인증 정보 추출
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth != null) {
+            // 새로운 SecurityContext에 인증 정보 복사
+            SecurityContext newContext = SecurityContextHolder.createEmptyContext();
+            newContext.setAuthentication(auth);
+
+            // Request에 SecurityContext 저장하여 이후 비동기 흐름에서 인증 정보 유지
+            new RequestAttributeSecurityContextRepository().saveContext(newContext, req, res);
+        }
+    }
+}

--- a/src/main/java/com/real/backend/security/filter/JwtFilter.java
+++ b/src/main/java/com/real/backend/security/filter/JwtFilter.java
@@ -28,11 +28,6 @@ public class JwtFilter extends OncePerRequestFilter {
     private final CookieUtils cookieUtils;
 
     @Override
-    protected boolean shouldNotFilterAsyncDispatch() {
-        return false;   // 기본 true → false 로 변경
-    }
-
-    @Override
     protected void doFilterInternal(@NonNull HttpServletRequest request, @NonNull HttpServletResponse response, @NonNull FilterChain filterChain) throws ServletException, IOException {
         // 건너 뛰어야 하는 경로 건너뛰기
         if (shouldSkip(request)) {


### PR DESCRIPTION
### Description

<!--
  간단하게 PR의 목적을 설명하세요.
  이 PR이 해결하려는 문제나 추가하려는 기능에 대해 요약해주세요.
-->

놓친 공지 및 읽지 않은 공지 관련 알림 SSE로 구현

### Related Issues

<!--
  관련된 이슈 번호를 참고하세요.
  예: Fixes #123, Closes #456
-->
- Resolves #246 

### Changes Made

<!--
  이 PR에서 변경된 사항을 설명하세요.
  코드, 문서, 설정 등 변경된 내용을 상세히 기술합니다.
-->

1. 로그인 시 연결할 수 있는 SSE 구현
2. 공지 생성시 알림 전달 
3. SSE가 연결되어있지 않을 때 생긴 알림을 전달하는 기능 구현

### Checklist

<!--
  PR 작성 시 다음 항목들을 확인하세요.
-->

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 모든 테스트가 성공적으로 통과했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.
- [x] 코드 리뷰어를 지정했습니다.

### Additional Notes

<!--
  리뷰어가 이해하는 데 도움이 될 추가적인 참고 사항이나 정보가 있다면 여기에 작성하세요.
-->

- 공지가 생성됐을 때는 알림을 전송할 때 Notification 레코드를 따로 생성하지 않습니다.
    - 하나의 공지가 생성됐을 때 모든 사용자를 위한 notification을 만드는 insert 쿼리가 대용량의 쓰기 부하를 발생시킬 것이라고 생각했습니다.
- 유실된 데이터는 last-event-id를 전달받아서, 그 id보다 큰 notice가 있을 때 sse로 send()합니다.