### PR TITLE
🐛fix: 챗봇 응답 종료시 access denied 오류 문제 해결

### DIFF
--- a/src/main/java/com/real/backend/modules/chatbot/controller/ChatbotController.java
+++ b/src/main/java/com/real/backend/modules/chatbot/controller/ChatbotController.java
@@ -10,8 +10,11 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.real.backend.modules.chatbot.service.ChatbotService;
 import com.real.backend.security.CurrentSession;
+import com.real.backend.security.SecurityContextUtil;
 import com.real.backend.security.Session;
 
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import reactor.core.publisher.Flux;
 
@@ -26,9 +29,11 @@ public class ChatbotController {
     @GetMapping(value = "/v2/chatbots", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public Flux<ServerSentEvent<String>> streamChatResponse(
         @RequestParam String question,
-        @CurrentSession Session session
+        @CurrentSession Session session,
+        HttpServletRequest httpServletRequest,
+        HttpServletResponse httpServletResponse
     ) {
-
+        SecurityContextUtil.propagateSecurityContextToRequest(httpServletRequest, httpServletResponse);
         return chatbotService.streamAnswer(question, session.getId());
     }
 }


### PR DESCRIPTION
### Description

<!--
  간단하게 PR의 목적을 설명하세요.
  이 PR이 해결하려는 문제나 추가하려는 기능에 대해 요약해주세요.
-->

sse 연결시 security context 전파하도록 변경

### Related Issues

<!--
  관련된 이슈 번호를 참고하세요.
  예: Fixes #123, Closes #456
-->
- Resolves #317 

### Changes Made

<!--
  이 PR에서 변경된 사항을 설명하세요.
  코드, 문서, 설정 등 변경된 내용을 상세히 기술합니다.
-->

1. chatbot controller에서 api 요청 시 SecurityContextUtil.propagateSecurityContextToRequest() 메서드 호출

### Checklist

<!--
  PR 작성 시 다음 항목들을 확인하세요.
-->

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 모든 테스트가 성공적으로 통과했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.
- [x] 코드 리뷰어를 지정했습니다.

### Additional Notes

<!--
  리뷰어가 이해하는 데 도움이 될 추가적인 참고 사항이나 정보가 있다면 여기에 작성하세요.
-->

sse 기능 구현하면서 기존의 ASYNC.Dispatcher()를 custom jwt filter에 통과하도록 하는 코드를 삭제하여 발생했던 문제. propagate를 이용하여 문제 해결.